### PR TITLE
compress multiple engines at once

### DIFF
--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -70,6 +70,8 @@ class CssAbsoluteFilter(FilterBase):
                 suffix = get_hashed_mtime(filename)
             elif settings.COMPRESS_CSS_HASHING_METHOD in ("hash", "content"):
                 suffix = get_hashed_content(filename)
+            elif settings.COMPRESS_CSS_HASHING_METHOD is None:
+                pass
             else:
                 raise FilterError('COMPRESS_CSS_HASHING_METHOD is configured '
                                   'with an unknown method (%s).' %

--- a/compressor/filters/newline_normalizer.py
+++ b/compressor/filters/newline_normalizer.py
@@ -1,0 +1,5 @@
+from compressor.filters import FilterBase
+
+class NewlineNormalizerFilter(FilterBase):
+    def input(self, **kwargs):
+        return self.content.replace("\r\n", "\n").replace("\r", "\n")

--- a/compressor/management/commands/compress_engines.py
+++ b/compressor/management/commands/compress_engines.py
@@ -1,0 +1,15 @@
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.utils.six import text_type
+from compressor.cache import get_offline_manifest, write_offline_manifest
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('engine', nargs='+', type=text_type)
+    
+    def handle(self, *args, **options):
+        manifest = {}
+        for engine in options['engine']:
+            call_command("compress", engine=engine)
+            manifest.update(get_offline_manifest())
+        write_offline_manifest(manifest)

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -70,7 +70,14 @@ class CompressorMixin(object):
             else:
                 raise OfflineGenerationError('You have offline compression '
                     'enabled but key "%s" is missing from offline manifest. '
-                    'You may need to run "python manage.py compress".' % key)
+                    'You may need to run "python manage.py compress".' 
+                    '\nThe content used to generate the key is as follows:\n%s'
+                    '\nThe offline manifest is as follows:\n%s' % (
+                        key,
+                        self.get_original_content(context),
+                        offline_manifest
+                    )
+                )
 
     def render_cached(self, compressor, kind, mode, forced=False):
         """


### PR DESCRIPTION
add management command to compress multiple engines at once

Usage:

```
python manage.py compress_engines django jinja2
```
